### PR TITLE
Fix `systemd` template to wait for network online

### DIFF
--- a/fishnet.py
+++ b/fishnet.py
@@ -1587,7 +1587,8 @@ def cmd_systemd(args):
     template = textwrap.dedent("""\
         [Unit]
         Description=Fishnet instance
-        After=network.target
+        After=network-online.target
+        Wants=network-online.target
 
         [Service]
         ExecStart={start}


### PR DESCRIPTION
The current implementation with `After=network.target` doesn't guarantee that `fishnet` will start on boot. 

In my case `systemd` would attempt to start `fishnet`, which would fail because network wasn't up. Too frequent failed attempts to restart would then make `systemd` decide to giveup:
```
Apr 27 08:59:17 cheetah systemd[1]: fishnet.service: Main process exited, code=exited, status=1/FAILURE
Apr 27 08:59:17 cheetah systemd[1]: fishnet.service: Unit entered failed state.
Apr 27 08:59:17 cheetah systemd[1]: fishnet.service: Failed with result 'exit-code'.
Apr 27 08:59:17 cheetah systemd[1]: fishnet.service: Service hold-off time over, scheduling restart.
Apr 27 08:59:17 cheetah systemd[1]: Stopped Fishnet instance.
Apr 27 08:59:17 cheetah systemd[1]: fishnet.service: Start request repeated too quickly.
Apr 27 08:59:17 cheetah systemd[1]: Failed to start Fishnet instance.
```

As per https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ the correct target is `network-online`.

I've tested this by rebooting my PC and it works flawlessly now.