### PR TITLE
use 'requests.post' json parameter for payloads

### DIFF
--- a/fishnet.py
+++ b/fishnet.py
@@ -644,7 +644,7 @@ class Worker(threading.Thread):
         try:
             # Report result and fetch next job
             response = requests.post(get_endpoint(self.conf, path),
-                                     data=json.dumps(request),
+                                     json=request,
                                      timeout=HTTP_TIMEOUT)
         except Exception:
             self.job = None


### PR DESCRIPTION
setting the payload as json also set the request Content-Type header to
application/json