### PR TITLE
RFC - Don't update engine if it is pinned.

### DIFF
--- a/fishnet.py
+++ b/fishnet.py
@@ -1149,6 +1149,8 @@ def load_conf(args):
 
     if hasattr(args, "engine_dir") and args.engine_dir is not None:
         conf.set("Fishnet", "EngineDir", args.engine_dir)
+    if hasattr(args, "engine_pinned") and args.engine_pinned is not None:
+        conf.set("Fishnet", "EnginePinned", str(args.engine_pinned))
     if hasattr(args, "stockfish_command") and args.stockfish_command is not None:
         conf.set("Fishnet", "StockfishCommand", args.stockfish_command)
     if hasattr(args, "key") and args.key is not None:
@@ -1908,6 +1910,7 @@ def main(argv):
     g = parser.add_argument_group("advanced")
     g.add_argument("--endpoint", help="lichess http endpoint (default: %s)" % DEFAULT_ENDPOINT)
     g.add_argument("--engine-dir", help="engine working directory")
+    g.add_argument("--engine-pinned", action="store_true", default=None, help="don't update the engine from github")
     g.add_argument("--stockfish-command", help="stockfish command (default: download precompiled Stockfish)")
     g.add_argument("--threads-per-process", "--threads", type=int, dest="threads", help="hint for the number of threads to use per engine process (default: %d)" % DEFAULT_THREADS)
     g.add_argument("--fixed-backoff", action="store_true", default=None, help="fixed backoff (only recommended for move servers)")

--- a/fishnet.py
+++ b/fishnet.py
@@ -978,6 +978,10 @@ def download_github_release(conf, release_page, filename):
     path = os.path.join(get_engine_dir(conf), filename)
     logging.info("Engine target path: %s", path)
 
+    if get_engine_pin(conf):
+        logging.info("Engine is pinned, skipping update")
+        return filename
+
     headers = {}
 
     # Only update to newer versions
@@ -1444,6 +1448,10 @@ def conf_get(conf, key, default=None, section="Fishnet"):
 
 def get_engine_dir(conf):
     return validate_engine_dir(conf_get(conf, "EngineDir"))
+
+
+def get_engine_pin(conf):
+    return bool(conf_get(conf, "EnginePinned"))
 
 
 def get_stockfish_command(conf, update=True):


### PR DESCRIPTION
I'm submitting this PR as a precursor to some other changes (multi-pv support etc).  We discussed the other changes in Montreal.   I have since realized that I will need to be able to pin the fishnet client to a specific version of the engine (set on the fishnet client side) in order for my system to work.

I wanted to run this by you before I moved forward with more changes. Is a feature like this amenable to you?  