### PR TITLE
Try to avoid IOError when stopping stockfish

### DIFF
--- a/fishnet.py
+++ b/fishnet.py
@@ -347,7 +347,12 @@ def kill_process(p):
         # Unix
         os.killpg(p.pid, signal.SIGKILL)
 
-    p.communicate()
+    # Try to avoid zombie by cleaning up any leftover stdout
+    try:
+        p.communicate()
+    except IOError:
+        # Can happen from duplicate communication to p
+        pass
 
 
 def send(p, line):


### PR DESCRIPTION
The current behavior is that if you press ^C a 2nd time fishnet has a good chance of breaking

```
$ python2 fishnet.py --endpoint $DEV_END --key $DEV_KEY --core=4 --threads-per-process=4

### Starting workers (press Ctrl + C to stop) ...

><> 1: Started Stockfish 11 64 POPCNT Multi-Variant, threads: ++++ (4), pid: 12367
><> 1: Analysing standard: https://lichess.dev/gc1gOPi1#47^C


### Stopping soon. Press ^C again to abort pending jobs ...

><> 1: Analysing standard: https://lichess.dev/gc1gOPi1#44^C


### Good bye! Aborting pending jobs ...

Traceback (most recent call last):
  File "fishnet.py", line 2159, in <module>
    sys.exit(main(sys.argv))
  File "fishnet.py", line 2143, in main
    sys.exit(commands[args.command](args))
  File "fishnet.py", line 1787, in cmd_run
    worker.stop()
  File "fishnet.py", line 625, in stop
    self.kill_stockfish()
  File "fishnet.py", line 796, in kill_stockfish
    kill_process(self.stockfish)
  File "fishnet.py", line 350, in kill_process
    p.communicate()
  File "/usr/lib/python2.7/subprocess.py", line 483, in communicate
    return self._communicate(input)
  File "/usr/lib/python2.7/subprocess.py", line 1124, in _communicate
    stdout, stderr = self._communicate_with_poll(input)
  File "/usr/lib/python2.7/subprocess.py", line 1204, in _communicate_with_poll
    close_unregister_and_remove(fd)
  File "/usr/lib/python2.7/subprocess.py", line 1161, in close_unregister_and_remove
    fd2file[fd].close()
IOError: close() called during concurrent operation on the same file object
```

This seems to happen always in python2 and rarely (if ever) in python3/pypy3.