### PR TITLE
build-stockfish.sh: Support other architectures

### DIFF
--- a/build-stockfish.sh
+++ b/build-stockfish.sh
@@ -13,20 +13,49 @@ fi
 
 echo "- Determining CPU architecture ..."
 
-ARCH=x86-64
-EXE=stockfish-x86_64
-
-if [ -f /proc/cpuinfo ]; then
-    if grep "^flags" /proc/cpuinfo | grep -q popcnt ; then
-        ARCH=x86-64-modern
-        EXE=stockfish-x86_64-modern
-    fi
-
-    if grep "^vendor_id" /proc/cpuinfo | grep -q Intel ; then
-        if grep "^flags" /proc/cpuinfo | grep bmi2 | grep -q popcnt ; then
-            ARCH=x86-64-bmi2
-            EXE=stockfish-x86_64-bmi2
+ARCH="$(uname -m)"
+EXE=stockfish-"$ARCH"
+case "$ARCH" in
+    aarch64|arm)
+        ARCH=armv7
+        EXE=stockfish-"$ARCH"
+        ;;
+    x86_64)
+        ARCH=x86-64
+        ;;
+    i*86)
+        # Assuming that everyone trying to run fishnet has SSE
+        ARCH=x86-32
+        ;;
+    ppc|ppcle)
+        ARCH=ppc-32
+        ;;
+    ppc64|ppc64le)
+        ARCH=ppc-64
+        ;;
+    *)
+        # If arch unknown, fall back to general config
+        if [ "$(getconf LONG_BIT)" = "64" ]; then
+            ARCH=general-64
+        else
+            ARCH=general-32
         fi
+        ;;
+esac
+
+if [ "$ARCH" = "x86-64" ]; then
+    if [ -f /proc/cpuinfo ]; then
+        if grep "^flags" /proc/cpuinfo | grep -q popcnt ; then
+            ARCH=x86-64-modern
+            EXE=stockfish-x86_64-modern
+        fi
+
+        if grep "^vendor_id" /proc/cpuinfo | grep -q Intel ; then
+            if grep "^flags" /proc/cpuinfo | grep bmi2 | grep -q popcnt ; then
+                ARCH=x86-64-bmi2
+                EXE=stockfish-x86_64-bmi2
+            fi
+       fi
     fi
 fi
 


### PR DESCRIPTION
Check for aarch64, and if so set ARCH and EXE to armv7.
Don't check for x86_64 CPU flags on non-x86_64 CPUs.
Case statement to check for Stockfish supported arches
(x86, ppc, ARM).
Fallback to general arch if unknown.

Note that the build will probably fail on other architectures if non-multilib GCC is installed (this is an issue with Stockfish upstream).