### PR TITLE
Add detection of ARMv8 to build script

### DIFF
--- a/build-stockfish.sh
+++ b/build-stockfish.sh
@@ -18,6 +18,11 @@ EXE=stockfish-"$ARCH"
 case "$ARCH" in
     aarch64|arm)
         ARCH=armv7
+        if [ -f /proc/cpuinfo ]; then
+            if grep "^CPU architecture" /proc/cpuinfo | grep -q 8 ; then
+                ARCH=armv8
+            fi
+        fi
         EXE=stockfish-"$ARCH"
         ;;
     x86_64)


### PR DESCRIPTION
With https://github.com/niklasf/Stockfish/pull/3 closed, the `fishnet` Stockfish fork now supports ARMv8 builds. This PR adds logic to differenctiate ARMv7 and ARMv8 processors using the data in `/proc/cpuinfo`. If it does not find a value or finds one other than `8`, the default behavior will be the current behavior of running an `ARCH=armv7` build of Stockfish.