### PR TITLE
Update Dockerfile and add shell entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM rust:latest AS builder
+FROM rust:1.48 AS builder
 WORKDIR /fishnet
 COPY . .
-RUN cargo build --release && strip target/release/fishnet
+RUN (git submodule update --init --recursive || true) && cargo build --release && strip target/release/fishnet
 
 # Not using alpine due to https://andygrove.io/2020/05/why-musl-extremely-slow/
 FROM debian:buster-slim
 COPY --from=builder /fishnet/target/release/fishnet /fishnet
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENV CORES=auto USER_BACKLOG=0s SYSTEM_BACKLOG=0s ENDPOINT=https://lichess.org/fishnet
-CMD /fishnet --no-conf --cores "$CORES" --user-backlog "$USER_BACKLOG" --system-backlog "$SYSTEM_BACKLOG" --endpoint "$ENDPOINT" --key "$KEY" run
+CMD ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+exec /fishnet --no-conf \
+    --key "$KEY"\
+    --cores "$CORES"\
+    --endpoint "$ENDPOINT"\
+    --user-backlog "$USER_BACKLOG"\
+    --system-backlog "$SYSTEM_BACKLOG"\
+    run


### PR DESCRIPTION
Building on @niklasf 's Dockerfile, I've made the following suggested changes:
- Use specific docker rust image version. Not super necessary, but can help prevent builds from breaking if rust updates their images. Can always be manually updated.
- Readd `(git submodule update --init --recursive || true)` to build command. Useful if someone downloads the repository and builds without cloning submodules first. `|| true` causes the bash command to succeed even if the previous command failed. (Relevant [stack overflow][1])
- Add a entrypoint [shell script][2]. Because of bash's `exec` command, the fishnet process should become the main process, and will properly handle SIGTEM when `docker stop` is run.
  - Things like debug flags can be handled within the shell script in the future

[1]: https://stackoverflow.com/a/53520372/7937009
[2]: https://github.com/niklasf/fishnet/issues/130#issuecomment-735931635