### PR TITLE
Modify exponential backoff progression

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -17,9 +17,12 @@ impl RandomizedBackoff {
     }
 
     pub fn next(&mut self) -> Duration {
-        let low = self.duration.as_millis() as u64;
-        let high = max(1, min(self.max_backoff.as_millis() as u64, (low + 100) * 2));
-        self.duration = Duration::from_millis(rand::thread_rng().gen_range(low, high));
+        let low = 100;
+        let cap = max(low, self.max_backoff.as_millis() as u64);
+        let last = self.duration.as_millis() as u64;
+        let high = 4 * max(low, last);
+        let t = min(cap, rand::thread_rng().gen_range(low, high));
+        self.duration = Duration::from_millis(t);
         self.duration
     }
 


### PR DESCRIPTION
Existing progression slowly approaches `max_backoff` - `rand(low, max_backoff)`. Proposed version caps the duration to `max_backoff` without slowly approaching it - `min(max_backoff, rand(low, high))`.

The minimum backoff duration is also capped to 100ms - previous limit was 1ms. Progression is changed to always be between 100ms and 4*previous.

Expected effect on network traffic is a worst case (queue always 0) increase of 50%, and reduction in traffic in general cases (job available >10% of the time).

```sh
# Before patch
D: Not enough backlogged jobs. Backing off 58ms.
D: Not enough backlogged jobs. Backing off 264ms.
D: Not enough backlogged jobs. Backing off 670ms.
D: Not enough backlogged jobs. Backing off 1.451s.
D: Not enough backlogged jobs. Backing off 1.751s.
D: Not enough backlogged jobs. Backing off 2.519s.
D: Not enough backlogged jobs. Backing off 3.594s.
D: Not enough backlogged jobs. Backing off 6.682s.
D: Not enough backlogged jobs. Backing off 7.263s.
D: Not enough backlogged jobs. Backing off 8.508s.
D: Not enough backlogged jobs. Backing off 8.716s.
D: Not enough backlogged jobs. Backing off 15.201s.
D: Not enough backlogged jobs. Backing off 28.262s.
D: Not enough backlogged jobs. Backing off 29.921s.
D: Not enough backlogged jobs. Backing off 29.944s.
D: Not enough backlogged jobs. Backing off 29.954s.
D: Not enough backlogged jobs. Backing off 29.981s.
D: Not enough backlogged jobs. Backing off 29.982s.
D: Not enough backlogged jobs. Backing off 29.984s.
D: Not enough backlogged jobs. Backing off 29.998s.

# After patch
D: No job received. Backing off 365ms.
D: No job received. Backing off 590ms.
D: No job received. Backing off 1.688s.
D: No job received. Backing off 770ms.
D: No job received. Backing off 1.286s.
D: No job received. Backing off 1.278s.
D: No job received. Backing off 4.589s.
D: No job received. Backing off 16.123s.
D: No job received. Backing off 1.509s.
D: No job received. Backing off 1.436s.
D: No job received. Backing off 1.702s.
D: No job received. Backing off 840ms.
D: No job received. Backing off 2.311s.
D: No job received. Backing off 3.871s.
D: No job received. Backing off 9.189s.
D: No job received. Backing off 8.929s.
D: No job received. Backing off 30s.
D: No job received. Backing off 30s.
D: No job received. Backing off 30s.
D: No job received. Backing off 30s.
D: No job received. Backing off 2.098s.
D: No job received. Backing off 7.664s.
D: No job received. Backing off 15.187s.
D: No job received. Backing off 24.288s.
D: No job received. Backing off 30s.
D: No job received. Backing off 30s.
D: No job received. Backing off 30s.
D: No job received. Backing off 30s.
D: No job received. Backing off 16.616s.
D: No job received. Backing off 28.237s.
D: No job received. Backing off 23.73s.
```