### PR TITLE
Avoid panic when stdout pipe closed

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -34,9 +34,14 @@ impl Logger {
         state.line_feed();
 
         if self.stderr {
-            eprintln!("{}", line);
+            let _ = writeln!(io::stderr(), "{}", line);
         } else {
-            println!("{}", line);
+            if let Err(e) = writeln!(io::stdout(), "{}", line) {
+                if e.kind() != io::ErrorKind::BrokenPipe {
+                    // Error when printing to stdout - print error to stderr
+                    let _ = writeln!(io::stderr(), "{}", e);
+                }
+	    }
         }
     }
 
@@ -81,7 +86,7 @@ impl Logger {
             io::stdout().flush().expect("flush stdout");
             state.progress_line = line.len();
         } else if self.verbose.level > 0 {
-            println!("{}", line);
+            self.println(&line);
         }
     }
 }
@@ -138,7 +143,7 @@ impl LoggerState {
     fn line_feed(&mut self) {
         if self.progress_line > 0 {
             self.progress_line = 0;
-            println!();
+            let _ = writeln!(io::stdout());
         }
     }
 }


### PR DESCRIPTION
Using `writeln!` instead of `println!`. It returns an `io::Result` instead of panicing, and we can handle it. As the logging isn't essential to the application, I'm mostly ignoring logger errors. If there is an error writing to stdout that isn't due to the pipe closing, we try to print that error to stderr. But otherwise we are ignoring the print errors.

Optionally `main.rs` could be modified to catch `SIGPIPE` and trigger a graceful shutdown. But there isn't a major issue with fishnet running silently in the background, so for now I haven't added that (plus adding the signal handler was a bit tricky as there isn't a matching signal for Windows, and the `select!` block wants matching signals).

I didn't change the printing in the `atty` progress section, as if we are `atty` I assume that means there isn't a pipe.

fixes #148 