### PR TITLE
Give FreeBSD binaries the proper path

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -364,31 +364,31 @@ const STOCKFISH_MV: &[Asset] = &[
 const STOCKFISH: &[Asset] = &[
     Asset {
         name: "stockfish-freebsd-x86-64-bmi2",
-        data: include_bytes!("../assets/stockfish-x86-64-bmi2.xz"),
+        data: include_bytes!("../assets/stockfish-freebsd-x86-64-bmi2.xz"),
         needs: Cpu::SF_BMI2,
         executable: true,
     },
     Asset {
         name: "stockfish-freebsd-x86-64-avx2",
-        data: include_bytes!("../assets/stockfish-x86-64-avx2.xz"),
+        data: include_bytes!("../assets/stockfish-freebsd-x86-64-avx2.xz"),
         needs: Cpu::SF_AVX2,
         executable: true,
     },
     Asset {
         name: "stockfish-freebsd-x86-64-sse41-popcnt",
-        data: include_bytes!("../assets/stockfish-x86-64-sse41-popcnt.xz"),
+        data: include_bytes!("../assets/stockfish-freebsd-x86-64-sse41-popcnt.xz"),
         needs: Cpu::SF_SSE41_POPCNT,
         executable: true,
     },
     Asset {
         name: "stockfish-freebsd-x86-64-ssse3",
-        data: include_bytes!("../assets/stockfish-x86-64-ssse3.xz"),
+        data: include_bytes!("../assets/stockfish-freebsd-x86-64-ssse3.xz"),
         needs: Cpu::SF_SSSE3,
         executable: true,
     },
     Asset {
         name: "stockfish-freebsd-x86-64",
-        data: include_bytes!("../assets/stockfish-x86-64.xz"),
+        data: include_bytes!("../assets/stockfish-freebsd-x86-64.xz"),
         needs: Cpu::SF_SSE2,
         executable: true,
     },
@@ -398,31 +398,31 @@ const STOCKFISH: &[Asset] = &[
 const STOCKFISH_MV: &[Asset] = &[
     Asset {
         name: "stockfish-mv-freebsd-x86-64-bmi2",
-        data: include_bytes!("../assets/stockfish-mv-x86-64-bmi2.xz"),
+        data: include_bytes!("../assets/stockfish-mv-freebsd-x86-64-bmi2.xz"),
         needs: Cpu::SF_BMI2,
         executable: true,
     },
     Asset {
         name: "stockfish-mv-freebsd-x86-64-avx2",
-        data: include_bytes!("../assets/stockfish-mv-x86-64-avx2.xz"),
+        data: include_bytes!("../assets/stockfish-mv-freebsd-x86-64-avx2.xz"),
         needs: Cpu::SF_AVX2,
         executable: true,
     },
     Asset {
         name: "stockfish-mv-freebsd-x86-64-sse41-popcnt",
-        data: include_bytes!("../assets/stockfish-mv-x86-64-sse41-popcnt.xz"),
+        data: include_bytes!("../assets/stockfish-mv-freebsd-x86-64-sse41-popcnt.xz"),
         needs: Cpu::SF_SSE41_POPCNT,
         executable: true,
     },
     Asset {
         name: "stockfish-mv-freebsd-x86-64-ssse3",
-        data: include_bytes!("../assets/stockfish-mv-x86-64-ssse3.xz"),
+        data: include_bytes!("../assets/stockfish-mv-freebsd-x86-64-ssse3.xz"),
         needs: Cpu::SF_SSSE3,
         executable: true,
     },
     Asset {
         name: "stockfish-mv-freebsd-x86-64",
-        data: include_bytes!("../assets/stockfish-mv-x86-64.xz"),
+        data: include_bytes!("../assets/stockfish-mv-freebsd-x86-64.xz"),
         needs: Cpu::SF_SSE2,
         executable: true,
     },


### PR DESCRIPTION
Tried to build the new commit, but it called a linux ELF. Looks like you forgot to add -freebsd- to the .xz path.

Once this is merged, I'll try again and confirm #163 is finally done