### PR TITLE
Reduces build times by caching Rust build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -32,6 +41,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -53,6 +71,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -75,6 +102,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -54,6 +63,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -79,6 +97,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -105,6 +132,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
Updates GitHub Actions with caching. Specifically, it reduces build times by caching Rust build artifacts. For example, Rust dependencies won't have to be downloaded for each workflow execution.

Details: 
https://github.com/actions/cache/blob/main/examples.md#rust---cargo

Expected outcome ...
1) On merge GitHub Actions will build as normal and there's no cache
`Cache not found for input keys`
2) Afterwards ... 
```
Run actions/cache@v2
Received 286510414 of 286510414 (100.0%), 103.3 MBs/sec
Cache Size: ~273 MB (286510414 B)
/bin/tar --use-compress-program zstd -d -xf /home/runner/work/_temp/[KEY]/cache.tzst -P -C /home/runner/work/fishnet/fishnet
Cache restored successfully
Cache restored from key: Linux-cargo-[KEY]
```

Build results with Rust caching:
* Details: https://github.com/gbedoya/fishnet/actions/runs/923004435
* Linux: 10m 6s
* Windows: 16m 16s
* MacOS 10.5: 12m 22s

Build results w/out caching:
* Details: https://github.com/niklasf/fishnet/actions/runs/879414826
* Linux: 15m 51s
* Windows: 18m 43s
* MacOS 10.5: 18m 14s