### PR TITLE
Mention the PKGBUILDs for Arch Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
    ./fishnet-x86_64-unknown-linux-gnu --auto-update
    ```
 
+   For Arch Linux users, there is [a PKGBUILD available](https://aur.archlinux.org/packages/fishnet-bin/).
+   
    Other useful commands:
 
    ```sh
@@ -41,6 +43,8 @@
    cargo run --release -vv --
    ```
 
+   There is also a PKGBUILD for compiling [the latest release](https://aur.archlinux.org/packages/fishnet/) or even [from the latest commit](https://aur.archlinux.org/packages/fishnet-git/).
+   
    **Docker**
 
    ```sh


### PR DESCRIPTION
Hi there,
I have decided to add your project to the Arch User Repository, so that Arch users can automatically install the binary or compile from source, using `makepkg`, a tool included in our package manager.
In case you aren't familiar, a [PKGBUILD](https://wiki.archlinux.org/title/PKGBUILD) is basically a bash script with all the instructions necessary to pull any dependencies, download the program, compile it if necessary, and then install it on the system.
I added one that works using the [latest binary](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fishnet-bin), the [latest source tarball](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fishnet), and also the [latest commit](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fishnet-git).

I think this will help give the project (and lichess) a bit more exposure in the Arch community, while also making it really easy and convenient to install :)