### PR TITLE
Adds new cargo-audit GH Actions workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: Security audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This following runs `cargo audit` in a new GH Actions workflow based on changes to Cargo.[toml | lock]

For example, when a vulnerability is encountered the Audit workflow fails ...
https://github.com/gbedoya/fishnet/actions/runs/1126236839

Note: the `audit-check` GH action code is configured to ignore warnings. Thus, it won't warn about how `cpuid` 10.0.0 has been yanked where as running `cargo audit` locally would.