### PR TITLE
Restart after auto-update on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -377,7 +377,9 @@ fn restart_process(current_exe: PathBuf, logger: &Logger) {
 fn restart_process(current_exe: PathBuf, logger: &Logger) {
     logger.headline(&format!("Waiting 5s before restarting {:?} ...", current_exe));
     thread::sleep(Duration::from_secs(5));
-    todo!("Restart on Windows");
+    std::process::Command::new(current_exe)
+        .args(std::env::args().into_iter().skip(1))
+        .spawn().expect("restarted");
 }
 
 async fn auto_update(verbose: bool, logger: Logger) -> Result<self_update::Status, self_update::errors::Error> {


### PR DESCRIPTION
Hello, here's an attempt to address issue #151. 

Basically I went ahead with spawning a child process. As a console application, it will connect to the same "conhost" and output to the same screen. I've also made a [toy example](https://github.com/kriolyth/self-restart) to see if there are caveats, and indeed _there are_.

This approach works as expected when the application is launched on its own and it created its own "conhost" instance. If it is launched from a terminal (cmd or powershell), then after parent application closes, terminal regains input and output. At the same time, the child also writes to same terminal window, but cannot process any input (not even Ctrl+C). Thankfully, closing the terminal window also stops the newly spawned application.

That means, the least surprising way to use autoupate is to create a link to the application, add an "--auto-update" flag and use the link to start application. Perhaps, if autoupdate was also an option in configuration file, the process would be even smoother.