### PR TITLE
Add version information to Windows executables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: stable-x86_64-pc-windows-gnu
           target: x86_64-pc-windows-gnu
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ raw-cpuid = "10"
 auditable-build = "0.1"
 glob = "0.3"
 xz2 = "0.1"
+
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -187,4 +187,14 @@ fn main() {
     stockfish_build();
     compress("Stockfish/src", EVAL_FILE);
     auditable_build::collect_dependency_list();
+
+    #[cfg(target_family = "windows")]
+    {
+        let res = winres::WindowsResource::new();
+        // Resuorce compilation may fail when toolchain does not match target,
+        // e.g. windows-msvc toolchain with windows-gnu target. 
+        res.compile().unwrap_or_else(|err| {
+            println!("cargo:warning=Resource compiler not invoked: {}", err);
+        });
+    }
 }


### PR DESCRIPTION
Hello all,

this patch is to resolve #164.
The resulting file will have some default information applied, as described by [winres crate](https://docs.rs/crate/winres).

![image](https://user-images.githubusercontent.com/2059973/132961297-5aa194ea-d352-454e-9349-2da5e4f7f445.png)
