### PR TITLE
Upgrades to Rust 1.56.0 and edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0+"
 authors = ["Niklas Fiekas <niklas.fiekas@backscattering.de>"]
 categories = ["command-line-utilities", "web-programming::http-client", "games"]
 keywords = ["chess", "lichess"]
-edition = "2018"
+edition = "2021"
 exclude = [
     "Stockfish/**/*.o",
     "Stockfish/**/*.s",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.54 AS builder
+FROM rust:1.56 AS builder
 WORKDIR /fishnet
 COPY . .
 RUN (git submodule update --init --recursive || true) && cargo build --release -vv && strip target/release/fishnet


### PR DESCRIPTION
Hi. This pull-request upgrades Rust to 1.56.0 and updates the Rust edition to 2021.

Background ...
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html

Migration to new edition details ...
```
➜  fishnet git:(master) ✗ cargo fix --edition --allow-dirty
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  itoa v0.4.8 (as host dependency) removed features: default, std
  syn v1.0.80 (as host dependency) removed features: visit
  tokio v1.12.0 removed features: winapi

    Checking fishnet v2.4.1-dev (/[...]/fishnet)
   Migrating src/main.rs from 2018 edition to 2021
    Finished dev [unoptimized + debuginfo] target(s) in 31.82s

➜  fishnet git:(master) ✗ vim Cargo.toml # To update Edition to 2021

➜  fishnet git:(master) ✗ cargo build
   Compiling cfg-if v1.0.0
   Compiling once_cell v1.8.0
   Compiling pin-project-lite v0.2.7
   Compiling bytes v1.1.0
   Compiling lazy_static v1.4.0
   Compiling untrusted v0.7.1
   Compiling spin v0.5.2
   Compiling hashbrown v0.11.2
   Compiling slab v0.4.5
   Compiling tinyvec_macros v0.1.0
   Compiling matches v0.1.9
   Compiling futures-io v0.3.17
   Compiling futures-sink v0.3.17
   Compiling pin-utils v0.1.0
   Compiling try-lock v0.2.3
   Compiling unicode-width v0.1.9
   Compiling base64 v0.13.0
   Compiling percent-encoding v2.1.0
   Compiling unicode-bidi v0.3.7
   Compiling ucd-trie v0.1.3
   Compiling regex-syntax v0.6.25
   Compiling ppv-lite86 v0.2.10
   Compiling tower-service v0.3.1
   Compiling httpdate v1.0.1
   Compiling bitflags v1.3.2
   Compiling number_prefix v0.3.0
   Compiling mime v0.3.16
   Compiling remove_dir_all v0.5.3
   Compiling ipnet v2.3.1
   Compiling vec_map v0.8.2
   Compiling termcolor v1.1.2
   Compiling os_str_bytes v3.1.0
   Compiling arrayvec v0.7.1
   Compiling thousands v0.2.0
   Compiling home v0.5.3
   Compiling configparser v2.1.0
   Compiling shell-escape v0.1.5
   Compiling auditable v0.1.0
   Compiling tinyvec v1.5.0
   Compiling tracing-core v0.1.21
   Compiling textwrap v0.14.2
   Compiling raw-cpuid v10.2.0
   Compiling form_urlencoded v1.0.1
   Compiling pest v2.1.3
   Compiling http v0.2.5
   Compiling memchr v2.4.1
   Compiling log v0.4.14
   Compiling futures-core v0.3.17
   Compiling proc-macro-nested v0.1.7
   Compiling futures-task v0.3.17
   Compiling httparse v1.5.1
   Compiling encoding_rs v0.8.28
   Compiling signal-hook-registry v1.4.0
   Compiling num_cpus v1.13.0
   Compiling getrandom v0.2.3
   Compiling socket2 v0.4.2
   Compiling terminal_size v0.1.17
   Compiling atty v0.2.14
   Compiling indexmap v1.7.0
   Compiling num-traits v0.2.14
   Compiling ring v0.16.20
   Compiling mio v0.7.13
   Compiling want v0.3.0
   Compiling futures-channel v0.3.17
   Compiling tracing v0.1.29
   Compiling aho-corasick v0.7.18
   Compiling quick-xml v0.20.0
   Compiling rand_core v0.6.3
   Compiling unicode-normalization v0.1.19
   Compiling futures-util v0.3.17
   Compiling serde_urlencoded v0.7.0
   Compiling serde_json v1.0.68
   Compiling clap v3.0.0-beta.4
   Compiling tokio v1.12.0
   Compiling semver-parser v0.10.2
   Compiling rand_chacha v0.3.1
   Compiling btoi v0.4.2
   Compiling serde_with v1.10.0
   Compiling rand v0.8.4
   Compiling shakmaty v0.20.1
   Compiling fishnet v2.4.1-dev (/[...]/fishnet)
   Compiling regex v1.5.4
   Compiling webpki v0.21.4
   Compiling sct v0.6.1
   Compiling semver v0.11.0
   Compiling http-body v0.4.3
   Compiling idna v0.2.3
   Compiling tempfile v3.2.0
   Compiling webpki-roots v0.21.1
   Compiling rustls v0.19.1
   Compiling url v2.2.2
   Compiling console v0.14.1
   Compiling indicatif v0.15.0
   Compiling tokio-util v0.6.8
   Compiling tokio-rustls v0.22.0
   Compiling h2 v0.3.6
   Compiling hyper v0.14.13
   Compiling hyper-rustls v0.22.1
   Compiling reqwest v0.11.5
   Compiling self_update v0.27.0
    Finished dev [unoptimized + debuginfo] target(s) in 10m 29s
```