### PR TITLE
Enable avx512 and vnni512 builds for stockfish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
           path: fishnet-x86_64-unknown-linux-gnu
   windows-x86-64:
     runs-on: windows-2019
+    env:
+      CXXFLAGS: -fno-asynchronous-unwind-tables
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
   windows-x86-64:
     runs-on: windows-2019
     needs: release
+    env:
+      CXXFLAGS: -fno-asynchronous-unwind-tables
     steps:
       - uses: actions/checkout@v2
         with:

--- a/build.rs
+++ b/build.rs
@@ -139,6 +139,27 @@ fn stockfish_build() {
     match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
         "x86_64" => {
             Target {
+                arch: "x86-64-vnni512",
+                #[cfg(target_arch = "x86_64")]
+                pgo:
+                    is_x86_feature_detected!("avx512dq") &&
+                    is_x86_feature_detected!("avx512vl") &&
+                    is_x86_feature_detected!("avx512vnni"),
+                #[cfg(not(target_arch = "x86_64"))]
+                pgo: false,
+            }
+            .build_both();
+
+            Target {
+                arch: "x86-64-avx512",
+                #[cfg(target_arch = "x86_64")]
+                pgo: is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw"),
+                #[cfg(not(target_arch = "x86_64"))]
+                pgo: false,
+            }
+            .build_both();
+
+            Target {
                 arch: "x86-64-bmi2",
                 #[cfg(target_arch = "x86_64")]
                 pgo: is_x86_feature_detected!("bmi2"),
@@ -172,9 +193,7 @@ fn stockfish_build() {
             .build_both();
 
             // TODO: Could support:
-            // - x86-64-avx512
-            // - x86-64-vnni256
-            // - x86-64-vnni512
+            // - x86-64-vnni256 - same as vnni512 but with register width 256
         }
         "aarch64" => {
             if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -186,6 +186,18 @@ const STOCKFISH: &[Asset] = &[
 #[cfg(all(unix, target_arch = "x86_64"))]
 const STOCKFISH_MV: &[Asset] = &[
     Asset {
+        name: "fairy-stockfish-x86-64-vnni512",
+        data: include_bytes!(concat!(env!("OUT_DIR"), "/fairy-stockfish-x86-64-vnni512.xz")),
+        needs: Cpu::SF_VNNI512,
+        executable: true,
+    },
+    Asset {
+        name: "fairy-stockfish-x86-64-avx512",
+        data: include_bytes!(concat!(env!("OUT_DIR"), "/fairy-stockfish-x86-64-avx512.xz")),
+        needs: Cpu::SF_AVX512,
+        executable: true,
+    },
+    Asset {
         name: "fairy-stockfish-x86-64-bmi2",
         data: include_bytes!(concat!(env!("OUT_DIR"), "/fairy-stockfish-x86-64-bmi2.xz")),
         needs: Cpu::SF_BMI2,
@@ -247,6 +259,24 @@ const STOCKFISH: &[Asset] = &[
 
 #[cfg(all(windows, target_arch = "x86_64"))]
 const STOCKFISH_MV: &[Asset] = &[
+    Asset {
+        name: "fairy-stockfish-x86-64-vnni512.exe",
+        data: include_bytes!(concat!(
+            env!("OUT_DIR"),
+            "/fairy-stockfish-x86-64-vnni512.exe.xz"
+        )),
+        needs: Cpu::SF_VNNI512,
+        executable: true,
+    },
+    Asset {
+        name: "fairy-stockfish-x86-64-avx512.exe",
+        data: include_bytes!(concat!(
+            env!("OUT_DIR"),
+            "/fairy-stockfish-x86-64-avx512.exe.xz"
+        )),
+        needs: Cpu::SF_AVX512,
+        executable: true,
+    },
     Asset {
         name: "fairy-stockfish-x86-64-bmi2.exe",
         data: include_bytes!(concat!(

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -229,6 +229,18 @@ const STOCKFISH_MV: &[Asset] = &[
 #[cfg(all(windows, target_arch = "x86_64"))]
 const STOCKFISH: &[Asset] = &[
     Asset {
+        name: "stockfish-x86-64-vnni512.exe",
+        data: include_bytes!(concat!(env!("OUT_DIR"), "/stockfish-x86-64-vnni512.exe.xz")),
+        needs: Cpu::SF_VNNI512,
+        executable: true,
+    },
+    Asset {
+        name: "stockfish-x86-64-avx512.exe",
+        data: include_bytes!(concat!(env!("OUT_DIR"), "/stockfish-x86-64-avx512.exe.xz")),
+        needs: Cpu::SF_AVX512,
+        executable: true,
+    },
+    Asset {
         name: "stockfish-x86-64-bmi2.exe",
         data: include_bytes!(concat!(env!("OUT_DIR"), "/stockfish-x86-64-bmi2.exe.xz")),
         needs: Cpu::SF_BMI2,

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -71,11 +71,15 @@ bitflags! {
         const SSE41     = 1 << 2;
         const AVX2      = 1 << 3;
         const FAST_BMI2 = 1 << 4;
+        const AVX512    = 1 << 5;
+        const VNNI512   = 1 << 6;
 
         const SF_SSE2         = Cpu::SSE2.bits;
         const SF_SSE41_POPCNT = Cpu::SSE41.bits | Cpu::POPCNT.bits;
         const SF_AVX2         = Cpu::SF_SSE41_POPCNT.bits | Cpu::AVX2.bits;
         const SF_BMI2         = Cpu::SF_AVX2.bits | Cpu::FAST_BMI2.bits;
+        const SF_AVX512       = Cpu::SF_BMI2.bits | Cpu::AVX512.bits;
+        const SF_VNNI512      = Cpu::SF_AVX512.bits | Cpu::VNNI512.bits;
     }
 }
 
@@ -111,6 +115,15 @@ impl Cpu {
                 }
             },
         );
+        cpu.set(Cpu::AVX512,
+            is_x86_feature_detected!("avx512f") &&
+            is_x86_feature_detected!("avx512bw")
+        );
+        cpu.set(Cpu::VNNI512,
+            is_x86_feature_detected!("avx512dq") &&
+            is_x86_feature_detected!("avx512vl") &&
+            is_x86_feature_detected!("avx512vnni")
+        );
         cpu
     }
 
@@ -129,6 +142,18 @@ const NNUE: Asset = Asset {
 
 #[cfg(all(unix, target_arch = "x86_64"))]
 const STOCKFISH: &[Asset] = &[
+    Asset {
+        name: "stockfish-x86-64-vnni512",
+        data: include_bytes!(concat!(env!("OUT_DIR"), "/stockfish-x86-64-vnni512.xz")),
+        needs: Cpu::SF_VNNI512,
+        executable: true,
+    },
+    Asset {
+        name: "stockfish-x86-64-avx512",
+        data: include_bytes!(concat!(env!("OUT_DIR"), "/stockfish-x86-64-avx512.xz")),
+        needs: Cpu::SF_AVX512,
+        executable: true,
+    },
     Asset {
         name: "stockfish-x86-64-bmi2",
         data: include_bytes!(concat!(env!("OUT_DIR"), "/stockfish-x86-64-bmi2.xz")),


### PR DESCRIPTION
Add detection of the AVX512 based features and build stockfish with that.
The vnni256 build is not done as it's the same as vnni512 but with
preferred register width 256. The CPU flags are the same so this cannot
be detected automatically and would have to be selected by user. Given the
results below it does not significantly improve things so it's probably
not worth the effort.

I've tested the build locally with fishnet client, subjectively the
reported knps increased by about 1000 but you don't have to believe
that.

Stockfish benchmark shows a minor NPS improvement for the accelerated
builds compared to BMI2, and if not at least it's not worse.
Sample short tc tournaments and and estimated Elo, calculated by ordo:

tc 1+1, 40 games

    # PLAYER        :  RATING  POINTS  PLAYED   (%)
    1 sf-bmi2       :  2317.6     8.5      16    53
    2 sf-vnni512    :  2317.6     8.5      16    53
    3 sf-vnni256    :  2317.6     8.5      16    53
    4 sf-avx2       :  2282.4     7.5      16    47
    5 sf-avx512     :  2264.7     7.0      16    44

tc 10+0.1, 40 games

    # PLAYER        :  RATING  POINTS  PLAYED   (%)
    1 sf-vnni512    :  2354.0     9.5      16    59
    2 sf-avx2       :  2335.9     9.0      16    56
    3 sf-vnni256    :  2318.0     8.5      16    53
    4 sf-avx512     :  2264.3     7.0      16    44
    5 sf-bmi2       :  2227.8     6.0      16    38

tc 10+1, 40 games

    # PLAYER        :  RATING  POINTS  PLAYED   (%)
    1 sf-avx2       :  2317.6     8.5      16    53
    2 sf-vnni512    :  2300.0     8.0      16    50
    3 sf-avx512     :  2300.0     8.0      16    50
    4 sf-bmi2       :  2300.0     8.0      16    50
    5 sf-vnni256    :  2282.4     7.5      16    47