### PR TITLE
fix: hint for submodule init on fresh repo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -487,18 +487,19 @@ fn append_file<W: Write, P: AsRef<Path>>(archive: &mut ar::Builder<W>, path: P, 
     archive.append(&header, file).unwrap();
 }
 
-fn copy_overwrite_submodule_folder(src: &Path, dst: &Path) {
+fn copy_overwrite_submodule_folder(from: &Path, to: &Path) {
+    let from_src = from.join("src");
     assert!(
-        src.is_dir(),
-        "Directory {src:?} does not exist. Try: git submodule update --init",
+        from_src.is_dir(),
+        "Directory {from_src:?} does not exist. Try: git submodule update --init",
     );
-    if dst.exists() {
-        fs::remove_dir_all(dst).unwrap();
+    if to.exists() {
+        fs::remove_dir_all(to).unwrap();
     }
-    fs::create_dir_all(dst).unwrap();
+    fs::create_dir_all(to).unwrap();
     fs_extra::dir::copy(
-        src,
-        dst,
+        from,
+        to,
         &fs_extra::dir::CopyOptions::new().content_only(true),
     )
     .unwrap();


### PR DESCRIPTION
Submodules need to be initialized before building on a fresh repo. There is an error message indicating this, but #278 introduced a bug where the warning is not shown anymore.

The root cause is that submodules are (empty) directories even if not yet initialized so checking if "submodule" is a directory always passes. Instead it should check "submodule/src", which should only exist if the submodule has been initialized.

I just saw #280 which supersedes #278 but I still posted this PR for the record and because the change is tiny, so it's probably safe to merge the fix.